### PR TITLE
Int cleanup

### DIFF
--- a/chattr.go
+++ b/chattr.go
@@ -1,3 +1,5 @@
+package chattr
+
 /*
 A package for change attribute of a file on Linux, similar to the chattr command.
 
@@ -17,7 +19,6 @@ Example to set the immutable attribute to a file:
         panic(err)
     }
 */
-package chattr
 
 import (
 	"os"
@@ -30,33 +31,33 @@ File attributes.
 */
 const (
 	// from /usr/include/linux/fs.h
-	FS_SECRM_FL        = 0x00000001 /* Secure deletion */
-	FS_UNRM_FL         = 0x00000002 /* Undelete */
-	FS_COMPR_FL        = 0x00000004 /* Compress file */
-	FS_SYNC_FL         = 0x00000008 /* Synchronous updates */
-	FS_IMMUTABLE_FL    = 0x00000010 /* Immutable file */
-	FS_APPEND_FL       = 0x00000020 /* writes to file may only append */
-	FS_NODUMP_FL       = 0x00000040 /* do not dump file */
-	FS_NOATIME_FL      = 0x00000080 /* do not update atime */
-	FS_DIRTY_FL        = 0x00000100
-	FS_COMPRBLK_FL     = 0x00000200 /* One or more compressed clusters */
-	FS_NOCOMP_FL       = 0x00000400 /* Don't compress */
-	FS_ENCRYPT_FL      = 0x00000800 /* Encrypted file */
-	FS_BTREE_FL        = 0x00001000 /* btree format dir */
-	FS_INDEX_FL        = 0x00001000 /* hash-indexed directory */
-	FS_IMAGIC_FL       = 0x00002000 /* AFS directory */
-	FS_JOURNAL_DATA_FL = 0x00004000 /* Reserved for ext3 */
-	FS_NOTAIL_FL       = 0x00008000 /* file tail should not be merged */
-	FS_DIRSYNC_FL      = 0x00010000 /* dirsync behaviour (directories only) */
-	FS_TOPDIR_FL       = 0x00020000 /* Top of directory hierarchies*/
-	FS_HUGE_FILE_FL    = 0x00040000 /* Reserved for ext4 */
-	FS_EXTENT_FL       = 0x00080000 /* Extents */
-	FS_EA_INODE_FL     = 0x00200000 /* Inode used for large EA */
-	FS_EOFBLOCKS_FL    = 0x00400000 /* Reserved for ext4 */
-	FS_NOCOW_FL        = 0x00800000 /* Do not cow file */
-	FS_INLINE_DATA_FL  = 0x10000000 /* Reserved for ext4 */
-	FS_PROJINHERIT_FL  = 0x20000000 /* Create with parents projid */
-	FS_RESERVED_FL     = 0x80000000 /* reserved for ext2 lib */
+	FS_SECRM_FL        uint32 = 0x00000001 /* Secure deletion */
+	FS_UNRM_FL                = 0x00000002 /* Undelete */
+	FS_COMPR_FL               = 0x00000004 /* Compress file */
+	FS_SYNC_FL                = 0x00000008 /* Synchronous updates */
+	FS_IMMUTABLE_FL           = 0x00000010 /* Immutable file */
+	FS_APPEND_FL              = 0x00000020 /* writes to file may only append */
+	FS_NODUMP_FL              = 0x00000040 /* do not dump file */
+	FS_NOATIME_FL             = 0x00000080 /* do not update atime */
+	FS_DIRTY_FL               = 0x00000100
+	FS_COMPRBLK_FL            = 0x00000200 /* One or more compressed clusters */
+	FS_NOCOMP_FL              = 0x00000400 /* Don't compress */
+	FS_ENCRYPT_FL             = 0x00000800 /* Encrypted file */
+	FS_BTREE_FL               = 0x00001000 /* btree format dir */
+	FS_INDEX_FL               = 0x00001000 /* hash-indexed directory */
+	FS_IMAGIC_FL              = 0x00002000 /* AFS directory */
+	FS_JOURNAL_DATA_FL        = 0x00004000 /* Reserved for ext3 */
+	FS_NOTAIL_FL              = 0x00008000 /* file tail should not be merged */
+	FS_DIRSYNC_FL             = 0x00010000 /* dirsync behaviour (directories only) */
+	FS_TOPDIR_FL              = 0x00020000 /* Top of directory hierarchies*/
+	FS_HUGE_FILE_FL           = 0x00040000 /* Reserved for ext4 */
+	FS_EXTENT_FL              = 0x00080000 /* Extents */
+	FS_EA_INODE_FL            = 0x00200000 /* Inode used for large EA */
+	FS_EOFBLOCKS_FL           = 0x00400000 /* Reserved for ext4 */
+	FS_NOCOW_FL               = 0x00800000 /* Do not cow file */
+	FS_INLINE_DATA_FL         = 0x10000000 /* Reserved for ext4 */
+	FS_PROJINHERIT_FL         = 0x20000000 /* Create with parents projid */
+	FS_RESERVED_FL            = 0x80000000 /* reserved for ext2 lib */
 
 )
 
@@ -69,7 +70,7 @@ const (
 	FS_IOC_SETFLAGS uintptr = 0x40086602
 )
 
-func ioctl(f *os.File, request uintptr, attrp *int32) error {
+func ioctl(f *os.File, request uintptr, attrp *uint32) error {
 
 	argp := uintptr(unsafe.Pointer(attrp))
 
@@ -85,9 +86,9 @@ func ioctl(f *os.File, request uintptr, attrp *int32) error {
 /*
 GetAttr retrieves the attributes of a file.
 */
-func GetAttrs(f *os.File) (int32, error) {
+func GetAttrs(f *os.File) (uint32, error) {
 
-	attr := int32(-1)
+	attr := uint32(1)
 
 	err := ioctl(f, FS_IOC_GETFLAGS, &attr)
 
@@ -97,7 +98,7 @@ func GetAttrs(f *os.File) (int32, error) {
 /*
 SetAttr sets the given attribute.
 */
-func SetAttr(f *os.File, attr int32) error {
+func SetAttr(f *os.File, attr uint32) error {
 
 	attrs, err := GetAttrs(f)
 
@@ -114,7 +115,7 @@ func SetAttr(f *os.File, attr int32) error {
 /*
 UnsetAttr unsets the given attribute.
 */
-func UnsetAttr(f *os.File, attr int32) error {
+func UnsetAttr(f *os.File, attr uint32) error {
 
 	attrs, err := GetAttrs(f)
 
@@ -130,7 +131,7 @@ func UnsetAttr(f *os.File, attr int32) error {
 /*
 IsAttr checks whether the given attribute is set.
 */
-func IsAttr(f *os.File, attr int32) (bool, error) {
+func IsAttr(f *os.File, attr uint32) (bool, error) {
 
 	attrs, err := GetAttrs(f)
 


### PR DESCRIPTION
So, a couple inconsistencies make this module a little irksome.

First, you defined ints for the const flags (since you don't declare what type they are), but the functions take int32s so an explicit conversion is necessary; an int [cannot be automatically casted to an int32](https://go.dev/play/p/9Q2WtO5utT5).

Secondly, you had an integer overflow by using the int32s.

`chattr.FS_RESERVED_FL` is defined as `0x80000000`, which is correct... but this is DEC `2147483648`.
This is [higher than Golang's int32 max](https://pkg.go.dev/builtin#int32) by 1, which [causes it to then overflow to `-2147483648`](https://go.dev/play/p/0S8EP16ZGsS).

All of these are resolved by using uint32's everywhere.